### PR TITLE
Write testcase before fixing case sensitive bloom filters and genomes bug

### DIFF
--- a/facs/utils/helpers.py
+++ b/facs/utils/helpers.py
@@ -16,32 +16,36 @@ import galaxy
 # Aux methods
 
 header='@HWI-ST188:2:1101:2751:1987#0/1'
-ecoli_read = \
-"""
-AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAA
-+
-@Paaceeefgggfhiifghiihgiiihiiiihhhhhhhfhgcgh_fegef
-"""
+ecoli_read = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAA"
+ecoli_qual = "@Paaceeefgggfhiifghiihgiiihiiiihhhhhhhfhgcgh_fegef"
 
-def generate_dummy_fastq(fname, num_reads):
+def generate_dummy_fastq(fname, num_reads, case=''):
     """ Generates simplest reads with dummy qualities
     """
     stride=13
 
     if not os.path.exists(fname):
         with open(fname, "w") as f:
-            f.write(header)
             # Spike one ecoli read
-            f.write(ecoli_read)
+            f.write(header + os.linesep)
+            if case == '':
+                f.write(ecoli_read + os.linesep)
+            elif case == '_lowercase':
+                f.write(ecoli_read.lower() + os.linesep)
+            elif case == '_mixedcase':
+                f.write(''.join(random.choice([str.upper, str.lower])(c) for c in ecoli_read) + os.linesep)
+           
+            f.write('+' + os.linesep) # FastQ separator
+            f.write(ecoli_qual + os.linesep)
 
             for r in xrange(num_reads):
                 # Identify reads uniquely for later debugging such as
                 # OpenMP parallel task distribution.
-                f.write(header + 'TASK ID: ' + str(r) + '\n')
+                f.write(header + 'TASK ID: ' + str(r) + os.linesep)
 
-                f.write('GATTACAT' * stride + '\n')
-                f.write('+' + '\n')
-                f.write('arvestad' * stride + '\n')
+                f.write('GATTACAT' * stride + os.linesep)
+                f.write('+' + os.linesep)
+                f.write('arvestad' * stride + os.linesep)
 
 ### Software management
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -54,9 +54,10 @@ class FacsBasicTest(unittest.TestCase):
         """ Generate dummy fastq files and query them against reference bloom filters.
         """
         for nreads in self.fastq_nreads:
-            test_fname = "test%s.fastq" % nreads
-            helpers.generate_dummy_fastq(os.path.join(self.synthetic_fastq,
-                                                      test_fname), nreads)
+            for case in ['','_lowercase']:
+                test_fname = "test%s%s.fastq" % (nreads, case)
+                helpers.generate_dummy_fastq(os.path.join(self.synthetic_fastq,
+                                                          test_fname), nreads, case)
 
         for ref in os.listdir(self.reference):
             qry = os.path.join(self.synthetic_fastq, test_fname)
@@ -69,7 +70,7 @@ class FacsBasicTest(unittest.TestCase):
             in data/custom folder.
         """
         for sample in glob.glob(os.path.join(self.custom_dir, "*.fastq")):
-            print "\nQuerying against uncompressed sample %s" % sample
+            print "\nQuerying custom sample %s" % sample
             for ref in os.listdir(self.reference):
-                facs.query(os.path.join(self.synthetic_fastq, test_fname),
+                facs.query(os.path.join(self.synthetic_fastq, sample),
                            os.path.join(self.bloom_dir, os.path.splitext(ref)[0]+".bloom"))


### PR DESCRIPTION
The test generates different case for ecoli reads, different genomes have different cases (hg19 vs GRCh37, for example).
