### PR TITLE
Add support for memory benchmarking

### DIFF
--- a/facs/utils/helpers.py
+++ b/facs/utils/helpers.py
@@ -104,11 +104,6 @@ def send_couchdb(server, db, user, passwd, doc, wake_up=False):
         pass
 
 
-def profile_call(cl):
-    """Just a wrapper around check_call so it can be profiled
-    """
-    subprocess.call(cl)
-
 ### Software management
 
 def _download_to_dir(url, dirname):

--- a/tests/test_fastqscreen.py
+++ b/tests/test_fastqscreen.py
@@ -111,7 +111,7 @@ class FastqScreenTest(unittest.TestCase):
                       "--outdir", self.tmp, "--conf", cfg.name, fastq_path]
                 mem = [-1]
                 if profile:
-                    mem = memory_usage((helpers.profile_call,([cl]),), include_children=True)
+                    mem = memory_usage((subprocess.call,([cl]),), include_children=True)
                 else:
                     subprocess.call(cl)
 


### PR DESCRIPTION
Profiles the memory usage and adds the corresponding information to the final json records.

Check [this](http://facs2.nopcode.org:5984/_utils/document.html?facs/6454e0822e48c768b02b036a44190721) doc as an example :-)

**Important note:** Requires the installation of the latest version of memory_profiler, download and install from [github](https://github.com/fabianp/memory_profiler).
