### PR TITLE
Add an extra cleanup at the end of the test, bowtie1 results got overriden by bowtie2

### DIFF
--- a/tests/test_fastqscreen.py
+++ b/tests/test_fastqscreen.py
@@ -59,8 +59,7 @@ class FastqScreenTest(unittest.TestCase):
                     helpers.send_couchdb(config.SERVER, config.FASTQ_SCREEN_DB, config.USERNAME, config.PASSWORD, res, wake_up=config.WAKE)
 
             # remove fastq_screen files from old test runs
-            shutil.rmtree(self.tmp)
-            os.mkdir(self.tmp)
+            _cleanup_fastq_screen_results()
         except:
             pass
 
@@ -132,9 +131,7 @@ class FastqScreenTest(unittest.TestCase):
                     # Clean to avoid parsing the wrong results file
                     os.remove(fastq_screen_resfile)
 
-        # remove fastq_screen files from old test runs (bowtie1 vs bowtie2 have the same results files)
-        shutil.rmtree(self.tmp)
-        os.mkdir(self.tmp)
+        _cleanup_fastq_screen_results()
 
     def test_3_run_fastq_screen_with_bowtie2(self):
         """ Runs fastq_screen using bowtie2 tests against synthetically generated fastq files folder.
@@ -180,9 +177,8 @@ class FastqScreenTest(unittest.TestCase):
                     # Clean to avoid parsing the wrong results file
                     os.remove(fastq_screen_resfile)
 
-        # remove fastq_screen files from old test runs (bowtie1 vs bowtie2 have the same results files)
-        shutil.rmtree(self.tmp)
-        os.mkdir(self.tmp)
+        _cleanup_fastq_screen_results()
+
 
     def _fastq_screen_metrics_to_json(self, in_handle, fastq_name, ref, start_time, end_time, mem):
         reader = csv.reader(in_handle, delimiter="\t")
@@ -297,3 +293,9 @@ class FastqScreenTest(unittest.TestCase):
 
         return self.config+config_dbs
 
+    def _cleanup_fastq_screen_results(self):
+        """ Delete results files across unit tests and teardown
+        """
+        # remove fastq_screen files from old test runs (bowtie1 vs bowtie2 have the same results files)
+        shutil.rmtree(self.tmp)
+        os.mkdir(self.tmp)


### PR DESCRIPTION
- Fastq_screen reported that results files where present and skipping tests for bowtie1. Forcing cleanup.
- The addition of `psutil` might have introduced a regression on `memory_profiler` logic:

```
Processing /pica/h1/roman/dev/facs/tests/data/synthetic_fastq/simngs_eschColi_K12_1000000.fastq
Counting sequences in /pica/h1/roman/dev/facs/tests/data/synthetic_fastq/simngs_eschColi_K12_1000000.fastq
Searching /pica/h1/roman/dev/facs/tests/data/synthetic_fastq/simngs_eschColi_K12_1000000.fastq against phiX
Process MemTimer-3:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 232, in _bootstrap
    self.run()
  File "/pica/h1/roman/.virtualenvs/facs/lib/python2.6/site-packages/memory_profiler.py", line 123, in run
    include_children=self.include_children)
  File "/pica/h1/roman/.virtualenvs/facs/lib/python2.6/site-packages/memory_profiler.py", line 51, in _get_memory
    mem += p.get_memory_info()[0] / _TWO_20
  File "/pica/h1/roman/.virtualenvs/facs/lib/python2.6/site-packages/psutil/__init__.py", line 758, in get_memory_info
    return self._platform_impl.get_memory_info()
  File "/pica/h1/roman/.virtualenvs/facs/lib/python2.6/site-packages/psutil/_pslinux.py", line 470, in wrapper
    raise NoSuchProcess(self.pid, self._process_name)
NoSuchProcess: process no longer exists (pid=17523)
```
